### PR TITLE
Fix #31 (deels?)

### DIFF
--- a/src/mollie/mollie.php
+++ b/src/mollie/mollie.php
@@ -105,7 +105,7 @@ function mollie_link($params, $method = Mollie_API_Object_Method::IDEAL)
             header('Location: ' . $payment->getCheckoutUrl());
             exit();
         } else {
-            $return = '<form action="" method="POST">';
+            $return = '<form action="' . $params['systemurl'] . '/viewinvoice.php?id=' . $params['invoiceid'] . '" method="POST">';
 
             if ($method == \Mollie\Api\Types\PaymentMethod::IDEAL) {
                 $issuers = $mollie->methods->get('ideal', ['include' => 'issuers'])->issuers;


### PR DESCRIPTION
Via email lijkt dit nog niet te werken (maar kan zijn omdat ik als admin ingelogd ben)
Als ik als klant naar de mail kijk via het klantenpaneel /clientarea.php?action=emails werkt de link wel en stuurt hij direct door naar de betaalpagina van de geselecteerde bank